### PR TITLE
Add `adapter` to setup to pass custom fetch instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "url": "https://github.com/mediamonks/jsonapi-client.git"
   },
   "dependencies": {
+    "@types/dedent": "^0.7.0",
+    "dedent": "^0.7.0",
     "isntnt": "^1.0.2"
   },
   "devDependencies": {

--- a/src/lib/ApiController.ts
+++ b/src/lib/ApiController.ts
@@ -1,4 +1,5 @@
 import { isArray, isUndefined, isNone } from 'isntnt'
+import dedent from 'dedent';
 
 import { EMPTY_OBJECT } from '../constants/data'
 import { createEmptyObject, createBaseResource, keys } from '../utils/data'
@@ -63,7 +64,15 @@ export class ApiController<S extends Partial<ApiSetup>> {
   }
 
   async handleRequest(url: URL, options: any): Promise<any> {
-    const request = await fetch(url.href, options)
+    if (isNone(this.api.setup.adapter)) {
+      throw new Error(dedent`No fetch adapter provided.
+        When not running in a browser that doesn't support fetch, you need to provide polyfill fetch.
+        When running in node, you can pass "node-fetch" as an adapter to the Api setup.
+        If you want to mock, you can use "fetch-mock".
+      `)
+    }
+
+    const request = await this.api.setup.adapter(url.href, options)
     return request.json()
   }
 

--- a/src/lib/ApiEndpoint.ts
+++ b/src/lib/ApiEndpoint.ts
@@ -5,7 +5,7 @@ import { Api } from './Api'
 import {
   ApiQuery,
   ApiQueryResourceParameters,
-  ApiQueryFilterParameters,
+  ApiQueryFiltersParameters,
   FetchQueryParameters,
 } from './ApiQuery'
 import { ApiSetup } from './ApiSetup'
@@ -62,7 +62,7 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
     })
   }
 
-  async fetch<Q extends ApiQueryFilterParameters<R, S>, F extends ApiQueryResourceParameters<R>>(
+  async fetch<Q extends ApiQueryFiltersParameters<R, S>, F extends ApiQueryResourceParameters<R>>(
     query: Q = EMPTY_OBJECT as Q,
     resourceFilter: F = EMPTY_OBJECT as F,
   ): Promise<FilteredResource<R, F>[]> {

--- a/src/lib/ApiSetup.ts
+++ b/src/lib/ApiSetup.ts
@@ -27,6 +27,7 @@ export type ApiSetup = {
   defaultIncludeFields: DefaultIncludeFieldsOption
   createPageQuery: ApiSetupCreatePageQuery
   parseRequestError: ApiSetupParseRequestError
+  adapter: ((input: RequestInfo, init?: RequestInit) => Promise<Response>) | undefined
 }
 
 export type ApiSetupCreatePageQuery =
@@ -41,6 +42,7 @@ export type DefaultApiSetup = ApiSetupWithDefaults<{
   defaultIncludeFields: DefaultIncludeFieldsOptions['NONE']
   createPageQuery: Transform<ApiQueryParameter, ApiQueryParameter>
   parseRequestError: Transform<ApiResponseError, any>
+  adapter: ((input: RequestInfo, init?: RequestInit) => Promise<Response>) | undefined
 }>
 
 export type ApiSetupWithDefaults<T extends Partial<ApiSetup>> = Required<
@@ -54,4 +56,5 @@ export const mergeApiDefaultSetup = mergeApiSetup({
   defaultIncludeFields: defaultIncludeFieldOptions.NONE,
   createPageQuery: reflect,
   parseRequestError: reflect,
+  adapter: typeof fetch !== 'undefined' ? fetch : undefined, // global fetch
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/dedent@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
+  integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -877,6 +882,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
This is mostly useful for mocking, or when running in node.js.