### PR TITLE
Add support for fetching relationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "jest": "^24.8.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.0.2",
-    "typescript": "^3.7.1-rc"
+    "typescript": "^3.7.2"
   }
 }

--- a/src/lib/Api.test.ts
+++ b/src/lib/Api.test.ts
@@ -1,83 +1,74 @@
-import {ApiQuery} from "./ApiQuery";
-import {Api} from "./Api";
-import set = Reflect.set;
-import {jsonApiVersions} from "../constants/jsonApi";
-import {defaultIncludeFieldOptions} from "../constants/setup";
+import { Api } from './Api'
+import { jsonApiVersions } from '../constants/jsonApi'
+import { defaultIncludeFieldOptions } from '../constants/setup'
 
-
-import { isString } from 'isntnt'
-import {resource} from "./Resource";
-import {requiredAttribute} from "./ResourceAttribute";
-
-export class Asset extends resource('Asset')<Asset> {
-  @requiredAttribute(isString) public assetType!: string
-  @requiredAttribute(isString) public name!: string
-  @requiredAttribute(isString) public alt!: string
-}
+import { Post } from '../test-utils/Entities'
 
 describe('Api', () => {
-
-
   describe('Api class', () => {
     describe('constructor', () => {
       it('should create a new default instancee', () => {
-        const url = 'https://www.example.com/api';
-        const api = new Api(new URL(url));
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
 
-        expect(api.url.href).toEqual(url);
-        expect(api.setup.createPageQuery).toBeDefined();
-        expect(api.setup.version).toBeDefined();
-        expect(api.setup.defaultIncludeFields).toBeDefined();
-        expect(api.setup.parseRequestError).toBeDefined();
-      });
+        expect(api.url.href).toEqual(url)
+        expect(api.setup.createPageQuery).toBeDefined()
+        expect(api.setup.version).toBeDefined()
+        expect(api.setup.defaultIncludeFields).toBeDefined()
+        expect(api.setup.parseRequestError).toBeDefined()
+      })
+
       it('should merge the default setup properly', () => {
-        const url = 'https://www.example.com/api';
+        const url = 'https://www.example.com/api'
         const setup = {
-          createPageQuery: (page:any) => ({
-            foo: 'bar'
+          createPageQuery: (page: any) => ({
+            foo: 'bar',
           }),
           version: jsonApiVersions['1_1'],
           defaultIncludeFields: defaultIncludeFieldOptions.PRIMARY,
-          parseRequestError: (all:any) => all,
-        };
-        const api = new Api(new URL(url), setup);
+          parseRequestError: (all: any) => all,
+        }
+        const api = new Api(new URL(url), setup)
 
-        expect(api.setup.createPageQuery).toEqual(setup.createPageQuery);
-        expect(api.setup.version).toEqual(setup.version);
-        expect(api.setup.defaultIncludeFields).toEqual(setup.defaultIncludeFields);
-        expect(api.setup.parseRequestError).toEqual(setup.parseRequestError);
-      });
-    });
+        expect(api.setup.createPageQuery).toEqual(setup.createPageQuery)
+        expect(api.setup.version).toEqual(setup.version)
+        expect(api.setup.defaultIncludeFields).toEqual(setup.defaultIncludeFields)
+        expect(api.setup.parseRequestError).toEqual(setup.parseRequestError)
+      })
+    })
 
     describe('endpoint', () => {
       it('should retrieve the endpoint', () => {
-        const url = 'https://www.example.com/api';
-        const api = new Api(new URL(url));
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
 
-        const endpoint = api.endpoint('/foo', Asset);
+        const endpoint = api.endpoint('/foo', Post)
 
-        expect(endpoint.api).toEqual(api);
+        expect(endpoint.api).toEqual(api)
       })
 
       it('should register the Resource', () => {
-        const url = 'https://www.example.com/api';
-        const api = new Api(new URL(url));
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
 
-        const endpoint = api.endpoint('/foo', Asset);
+        const endpoint = api.endpoint('/foo', Post)
 
-        expect(endpoint.api.controller.getResource('Asset')).toEqual(Asset);
+        // endpoint.getRelationship('123', 'author', { fields: { Author: ['name'] } })
+        // endpoint.fetchRelationship('123', 'comments', {}, { fields: { Comment: ['title'] } })
+
+        expect(endpoint.api.controller.getResource('Post')).toEqual(Post)
       })
     })
 
     describe('register', () => {
       it('should register a Resource', () => {
-        const url = 'https://www.example.com/api';
-        const api = new Api(new URL(url));
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
 
-        api.register(Asset);
+        api.register(Post)
 
-        expect(api.controller.getResource('Asset')).toEqual(Asset);
+        expect(api.controller.getResource('Post')).toEqual(Post)
       })
     })
-  });
-});
+  })
+})

--- a/src/lib/ApiController.ts
+++ b/src/lib/ApiController.ts
@@ -22,7 +22,7 @@ import { RelationshipField, RelationshipValue } from './ResourceRelationship'
 
 type ApiResources = Record<string, ResourceConstructor<AnyResource>>
 
-type ResourceData<R extends AnyResource> = ResourceIdentifier<R['type']> & {
+export type ResourceData<R extends AnyResource> = ResourceIdentifier<R['type']> & {
   attributes: ResourceAttributes<R>
   relationships: ResourceRelationships<R>
 }

--- a/src/lib/ApiEndpoint.test.ts
+++ b/src/lib/ApiEndpoint.test.ts
@@ -1,23 +1,19 @@
-import { ApiEndpoint } from './ApiEndpoint'
+import { ApiEndpoint, FilteredResource } from './ApiEndpoint'
 import { Api } from './Api'
 import { resource } from './Resource'
 import { requiredAttribute } from './ResourceAttribute'
 import { isString } from 'isntnt'
-import { ApiQuery } from './ApiQuery'
 import { Result } from '../utils/Result'
-
-export class Asset extends resource('Asset')<Asset> {
-  @requiredAttribute(isString) public assetType!: string
-  @requiredAttribute(isString) public name!: string
-  @requiredAttribute(isString) public alt!: string
-}
+import { ApiCollectionResult, ApiEntityResult } from './ApiResult'
+import { mockData } from '../test-utils/mock-data'
+import { Author, Post, Comment } from '../test-utils/Entities'
 
 describe('ApiEndpoint', () => {
   describe('ApiEndpoint class', () => {
     describe('constructor', () => {
       it('should create a new default instance', () => {
         const api = new Api(new URL('https://www.example.com/api'))
-        const endpoint = api.endpoint('/assets', Asset)
+        const endpoint = api.endpoint('/posts', Post)
 
         expect(endpoint).toBeDefined()
       })
@@ -58,103 +54,168 @@ describe('ApiEndpoint', () => {
     describe('get', () => {
       it('should get a resource item', async () => {
         const api = new Api(new URL('https://www.example.com/api'))
-        const endpoint = api.endpoint('/assets', Asset)
-
-        const data = {
-          type: 'Asset',
-          id: '123',
-          assetType: 'foo',
-          name: 'foo',
-          alt: 'foo',
-        } as const
+        const endpoint = api.endpoint('/posts', Post)
 
         const mockHandleRequest = jest.fn(
-          (): Promise<Result<any, never>> => {
-            return new Promise((resolve) => {
-              resolve(
-                Result.accept({
-                  data: {
-                    type: data.type,
-                    id: data.id,
-                    attributes: {
-                      assetType: data.assetType,
-                      name: data.name,
-                      alt: data.alt,
-                    },
-                  },
-                }),
-              )
-            })
-          },
+          (): Promise<Result<any, never>> =>
+            Promise.resolve(
+              Result.accept({
+                data: mockData.Post.p1,
+              }),
+            ),
         )
 
         api.controller.handleRequest = mockHandleRequest
 
         const item = await endpoint.get('123')
 
-        expect(item).toMatchObject(data)
-        expect(item).toBeInstanceOf(Asset)
+        expect(item.data).toMatchObject({
+          id: 'p1',
+          type: 'Post',
+          title: 'Post 1',
+          content: 'foo',
+        })
+        expect(item.data).toBeInstanceOf(Post)
+        expect(item).toBeInstanceOf(ApiEntityResult)
       })
     })
 
     describe('fetch', () => {
       it('should get a list of resources', async () => {
         const api = new Api(new URL('https://www.example.com/api'))
-        const endpoint = api.endpoint('/assets', Asset)
-
-        const data = {
-          type: 'Asset',
-          id: '123',
-          assetType: 'foo',
-          name: 'foo',
-          alt: 'foo',
-        } as const
+        const endpoint = api.endpoint('/posts', Post)
 
         const mockHandleRequest = jest.fn(
-          (): Promise<Result<any, never>> => {
-            return new Promise((resolve) => {
-              resolve(
-                Result.accept({
-                  data: [
-                    {
-                      type: data.type,
-                      id: data.id,
-                      attributes: {
-                        assetType: data.assetType,
-                        name: data.name,
-                        alt: data.alt,
-                      },
-                    },
-                  ],
-                }),
-              )
-            })
-          },
+          (): Promise<Result<any, never>> =>
+            Promise.resolve(
+              Result.accept({
+                data: [mockData.Post.p1],
+              }),
+            ),
         )
 
         api.controller.handleRequest = mockHandleRequest
 
-        const items = await endpoint.fetch()
+        let items
+        try {
+          items = await endpoint.fetch({}, { fields: { Post: ['title', 'content'] } })
+        } catch (errors) {
+          console.log(errors)
+          throw errors
+        }
 
-        expect(items).toEqual(expect.arrayContaining([expect.objectContaining(data)]))
+        expect(items.data).toEqual([
+          {
+            id: 'p1',
+            type: 'Post',
+            title: 'Post 1',
+            content: 'foo',
+          },
+        ])
+      })
+    })
+
+    describe('getRelationshipEntity', () => {
+      it('should fetch a one-to-one relationship', async () => {
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
+
+        const endpoint = api.endpoint('/posts', Post)
+        api.register(Author)
+
+        const mockHandleRequest = jest.fn(
+          (): Promise<Result<any, never>> =>
+            Promise.resolve(
+              Result.accept({
+                data: mockData.Author.a1,
+              }),
+            ),
+        )
+
+        api.controller.handleRequest = mockHandleRequest
+
+        let item: ApiEntityResult<FilteredResource<Author, { fields: { Author: ['name'] } }>, any>
+        try {
+          item = await endpoint.getRelationshipEntity('123', 'author', {
+            fields: { Author: ['name'] },
+          })
+        } catch (errors) {
+          console.log(errors)
+          throw errors
+        }
+        if (item) {
+          expect(item.data).toEqual({
+            id: 'a1',
+            type: 'Author',
+            name: 'Narie',
+          })
+          expect(item.data).toBeInstanceOf(Author)
+        }
+        // endpoint.fetchRelationship('123', 'comments', {}, { fields: { Comment: ['title'] } })
+      })
+    })
+
+    describe('getRelationshipCollection', () => {
+      it('should fetch a one-to-many relationship', async () => {
+        const url = 'https://www.example.com/api'
+        const api = new Api(new URL(url))
+
+        const endpoint = api.endpoint('/posts', Post)
+        api.register(Comment)
+
+        const mockHandleRequest = jest.fn(
+          (): Promise<Result<any, never>> =>
+            Promise.resolve(
+              Result.accept({
+                data: [mockData.Comment.c1],
+              }),
+            ),
+        )
+        api.controller.handleRequest = mockHandleRequest
+
+        let item: ApiCollectionResult<
+          FilteredResource<Comment, { fields: { Comment: ['title'] } }>,
+          any
+        >
+        try {
+          item = await endpoint.getRelationshipCollection(
+            '123',
+            'comments',
+            {},
+            { fields: { Comment: ['title'] } },
+          )
+        } catch (errors) {
+          console.log(errors)
+          throw errors
+        }
+        if (item) {
+          expect(item.data).toEqual([
+            {
+              id: 'c1',
+              type: 'Comment',
+              title: 'Comment 1',
+            },
+          ])
+          expect(item.data[0]).toBeInstanceOf(Comment)
+        }
       })
     })
 
     describe('toString', () => {
       it('should return the endpoint path', () => {
         const api = new Api(new URL('https://www.example.com/api/'))
-        const endpoint = api.endpoint('assets', Asset)
+        const endpoint = api.endpoint('posts', Post)
 
-        expect(endpoint.toString()).toEqual('https://www.example.com/api/assets')
+        expect(endpoint.toString()).toEqual('https://www.example.com/api/posts')
       })
     })
 
     describe('toURL', () => {
       it('should return the endpoint path as a URL', () => {
         const api = new Api(new URL('https://www.example.com/api/'))
-        const endpoint = api.endpoint('assets', Asset)
+        const endpoint = api.endpoint('posts', Post)
 
-        expect(endpoint.toURL().href).toEqual('https://www.example.com/api/assets')
+        expect(endpoint.toURL().href).toEqual('https://www.example.com/api/posts')
       })
     })
   })

--- a/src/lib/ApiEndpoint.test.ts
+++ b/src/lib/ApiEndpoint.test.ts
@@ -114,7 +114,7 @@ describe('ApiEndpoint', () => {
       })
     })
 
-    describe('getRelationshipEntity', () => {
+    describe('getToOneRelationship', () => {
       it('should fetch a one-to-one relationship', async () => {
         const url = 'https://www.example.com/api'
         const api = new Api(new URL(url))
@@ -133,7 +133,7 @@ describe('ApiEndpoint', () => {
         let item: ApiEntityResult<FilteredResource<Author, { fields: { Author: ['name'] } }>, any>
         try
         {
-          item = await endpoint.getRelationshipEntity('123', 'author', {
+          item = await endpoint.getToOneRelationship('123', 'author', {
             fields: {Author: ['name']},
           })
         } catch (errors)
@@ -155,7 +155,7 @@ describe('ApiEndpoint', () => {
       })
     })
 
-    describe('getRelationshipCollection', () => {
+    describe('getToManyRelationship', () => {
       it('should fetch a one-to-many relationship', async () => {
         const url = 'https://www.example.com/api'
         const api = new Api(new URL(url))
@@ -174,7 +174,7 @@ describe('ApiEndpoint', () => {
           any>
         try
         {
-          item = await endpoint.getRelationshipCollection(
+          item = await endpoint.getToManyRelationship(
             '123',
             'comments',
             {},

--- a/src/lib/ApiEndpoint.ts
+++ b/src/lib/ApiEndpoint.ts
@@ -122,7 +122,7 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
    * @param relationshipFieldName
    * @param resourceFilter
    */
-  async getRelationshipEntity<
+  async getToOneRelationship<
     RI extends ResourceToOneRelationshipNames<R>,
     RR extends Extract<R[RI], AnyResource>,
     F extends ApiQueryResourceParameters<RR>
@@ -152,7 +152,7 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
    * @param query
    * @param resourceFilter
    */
-  async getRelationshipCollection<
+  async getToManyRelationship<
     RI extends ResourceToManyRelationshipNames<R>,
     RR extends R[RI] extends ToManyRelationship<AnyResource> ? R[RI][number] : never,
     Q extends ApiQueryFiltersParameters<RR, S>,

--- a/src/lib/ApiEndpoint.ts
+++ b/src/lib/ApiEndpoint.ts
@@ -4,9 +4,25 @@ import { createGetRequestOptions, keys, createPostRequestOptions } from '../util
 import { Api } from './Api'
 import { ApiQuery, ApiQueryResourceParameters, ApiQueryFiltersParameters } from './ApiQuery'
 import { ApiSetup } from './ApiSetup'
-import { AnyResource, ResourceConstructor, ResourceCreateValues, ResourceId } from './Resource'
+import {
+  AnyResource,
+  ResourceConstructor,
+  ResourceCreateValues,
+  ResourceId,
+  ResourceToManyRelationshipNames,
+  ResourceToOneRelationshipNames,
+  ResourceType,
+} from './Resource'
 import { ResourceIdentifierKey, ResourceIdentifier } from './ResourceIdentifier'
-import { SingleApiResult, PaginatedApiResult } from './ApiResult'
+import { ApiEntityResult, ApiCollectionResult } from './ApiResult'
+import {
+  ToManyRelationship,
+  ToManyRelationshipField,
+  ToOneRelationshipField,
+} from './ResourceRelationship'
+import { Result } from '../utils/Result'
+import { ResourceData } from './ApiController'
+import { ApiError } from './ApiError'
 
 export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
   readonly api: Api<S>
@@ -61,28 +77,114 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
     })
   }
 
+  /**
+   * Get a single entity
+   * /api/posts/123
+   *
+   * @param id
+   * @param resourceFilter
+   */
   async get<F extends ApiQueryResourceParameters<R>>(
     id: ResourceId,
     resourceFilter: F = EMPTY_OBJECT as F,
-  ): Promise<SingleApiResult<FilteredResource<R, F>, any>> {
+  ): Promise<ApiEntityResult<FilteredResource<R, F>, any>> {
+    return this.fetchEntity(id, resourceFilter) as any
+  }
+
+  /**
+   * Get an entity collection
+   * /api/posts/
+   *
+   * @param query
+   * @param resourceFilter
+   */
+  async fetch<Q extends ApiQueryFiltersParameters<R, S>, F extends ApiQueryResourceParameters<R>>(
+    query: Q = EMPTY_OBJECT as Q,
+    resourceFilter: F = EMPTY_OBJECT as F,
+  ): Promise<ApiCollectionResult<FilteredResource<R, F>, any>> {
+    return this.fetchCollection(query as any, resourceFilter) as any
+  }
+
+  /**
+   * Fetch a 1-to-1 relationship for an entity
+   * /api/posts/123/author
+   *
+   * @param id
+   * @param relationshipFieldName
+   * @param resourceFilter
+   */
+  async getRelationshipEntity<
+    RI extends ResourceToOneRelationshipNames<R>,
+    RR extends Extract<R[RI], AnyResource>,
+    F extends ApiQueryResourceParameters<RR>
+  >(
+    id: ResourceId,
+    relationshipFieldName: RI,
+    resourceFilter: F = EMPTY_OBJECT as F,
+  ): Promise<ApiEntityResult<FilteredResource<RR, F>, any>> {
+    const relationshipField = this.Resource.fields[relationshipFieldName] as ToOneRelationshipField<
+      RR['type']
+    >
+
+    return (this.fetchEntity(
+      id,
+      resourceFilter as any,
+      `${relationshipFieldName}/`,
+      relationshipField.type,
+    ) as unknown) as Promise<ApiEntityResult<FilteredResource<RR, F>, any>>
+  }
+
+  /**
+   * Fetch a 1-to-many relationship for an entity
+   * /api/posts/123/comments
+   *
+   * @param id
+   * @param relationshipFieldName
+   * @param query
+   * @param resourceFilter
+   */
+  async getRelationshipCollection<
+    RI extends ResourceToManyRelationshipNames<R>,
+    RR extends R[RI] extends ToManyRelationship<AnyResource> ? R[RI][number] : never,
+    Q extends ApiQueryFiltersParameters<RR, S>,
+    F extends ApiQueryResourceParameters<RR>
+  >(
+    id: ResourceId,
+    relationshipFieldName: RI,
+    query: Q = EMPTY_OBJECT as Q,
+    resourceFilter: F = EMPTY_OBJECT as F,
+  ): Promise<ApiCollectionResult<FilteredResource<RR, F>, any>> {
+    const relationshipField: ToManyRelationshipField<RR['type']> = this.Resource.fields[
+      relationshipFieldName
+    ] as any
+
+    return (this.fetchCollection(
+      query as any,
+      resourceFilter as any,
+      id,
+      `${id}/${relationshipFieldName}/`,
+      relationshipField.type,
+    ) as unknown) as Promise<ApiCollectionResult<FilteredResource<RR, F>, any>>
+  }
+
+  private async fetchEntity<F extends ApiQueryResourceParameters<AnyResource>>(
+    id: ResourceId,
+    resourceFilter: F = EMPTY_OBJECT as F,
+    relationshipPath: string = '',
+    relationResourceType: ResourceType = '',
+  ): Promise<ApiEntityResult<FilteredResource<AnyResource, F>, any>> {
     const queryParameters = new ApiQuery(this.api, { ...resourceFilter })
-    const url = new URL(`${this.path}/${id}${String(queryParameters)}`, this.api.url)
+    const url = new URL(`${id}${relationshipPath}${String(queryParameters)}`, this.toURL())
 
     const options = createGetRequestOptions()
     return new Promise(async (resolve, reject) => {
       this.api.controller.handleRequest(url, options).then((request) => {
-        const result = request.flatMap((response) => {
-          return this.api.controller.decodeResource(
-            this.Resource.type,
-            response.data,
-            response.included,
-            resourceFilter.fields,
-            resourceFilter.include,
-            [this.Resource.type, id],
-          )
-        })
+        const result = request.flatMap((response) =>
+          this.processResponse(response, response.data, resourceFilter, id, relationResourceType),
+        )
+
         if (result.isSuccess()) {
-          resolve(new SingleApiResult(result.value, request.value.meta) as any)
+          resolve(new ApiEntityResult(result.value, request.value.meta) as any)
         } else {
           reject(result.value)
         }
@@ -90,12 +192,18 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
     })
   }
 
-  async fetch<Q extends ApiQueryFiltersParameters<R, S>, F extends ApiQueryResourceParameters<R>>(
+  private async fetchCollection<
+    Q extends ApiQueryFiltersParameters<AnyResource, S>,
+    F extends ApiQueryResourceParameters<R>
+  >(
     query: Q = EMPTY_OBJECT as Q,
     resourceFilter: F = EMPTY_OBJECT as F,
-  ): Promise<PaginatedApiResult<FilteredResource<R, F>, any>> {
+    id: ResourceId = '',
+    relationshipPath: string = '',
+    relationResourceType: ResourceType = '',
+  ): Promise<ApiCollectionResult<FilteredResource<AnyResource, F>, any>> {
     const queryParameters = new ApiQuery(this.api, { ...query, ...resourceFilter })
-    const url = new URL(String(queryParameters), this.toURL())
+    const url = new URL(`${relationshipPath}${String(queryParameters)}`, this.toURL())
 
     return new Promise((resolve, reject) => {
       const options = createGetRequestOptions()
@@ -105,14 +213,14 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
           const values: Array<FilteredResource<R, F>> = []
 
           response.data.forEach((resource: any) => {
-            const result = this.api.controller.decodeResource(
-              this.Resource.type,
+            const result = this.processResponse(
+              response,
               resource,
-              response.included,
-              resourceFilter.fields,
-              resourceFilter.include,
-              [this.Resource.type, resource.id],
+              resourceFilter,
+              id,
+              relationResourceType,
             )
+
             if (result.isSuccess()) {
               values.push(result.value as any)
             } else {
@@ -123,11 +231,43 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
           if (errors.length) {
             reject(errors)
           } else {
-            resolve(new PaginatedApiResult(values as Array<any>, response.meta))
+            resolve(new ApiCollectionResult(values as Array<any>, response.meta))
           }
         })
       })
     })
+  }
+
+  private processResponse(
+    response: any,
+    resource: ResourceData<AnyResource>,
+    resourceFilter: ApiQueryResourceParameters<AnyResource>,
+    parentId: ResourceId = '',
+    relationResourceType: ResourceType = '',
+  ): Result<AnyResource | null, ApiError<any>[]> {
+    if (relationResourceType) {
+      if (response === null) {
+        return Result.accept(null)
+      }
+
+      return this.api.controller.decodeResource(
+        relationResourceType,
+        resource,
+        response.included,
+        resourceFilter.fields,
+        resourceFilter.include,
+        [this.Resource.type, parentId, relationResourceType],
+      )
+    }
+
+    return this.api.controller.decodeResource(
+      this.Resource.type,
+      resource,
+      response.included,
+      resourceFilter.fields,
+      resourceFilter.include,
+      [this.Resource.type, resource.id],
+    )
   }
 
   toString(): string {

--- a/src/lib/ApiQuery.ts
+++ b/src/lib/ApiQuery.ts
@@ -38,7 +38,7 @@ export type ApiQueryIncludeParameter<R extends AnyResource> = BaseApiQueryInclud
 
 export type ApiQueryFieldsParameter<R extends AnyResource> = BaseApiQueryFieldsParameter<R>
 
-type BaseRelationshipResource<T> = T extends Array<AnyResource>
+export type BaseRelationshipResource<T> = T extends Array<AnyResource>
   ? T[number]
   : Extract<T, AnyResource>
 
@@ -177,7 +177,7 @@ const parseApiQueryParameterArray = (value: Array<string | number>): string => {
     .join(LIST_PARAMETER_VALUE_DELIMITER)
 }
 
-type BaseApiQueryIncludeParameters<T> = T extends RelationshipValue<AnyResource>
+export type BaseApiQueryIncludeParameters<T> = T extends RelationshipValue<AnyResource>
   ?
       | null
       | {

--- a/src/lib/ApiResult.ts
+++ b/src/lib/ApiResult.ts
@@ -1,4 +1,4 @@
-export class SingleApiResult<T, M> {
+export class ApiEntityResult<T, M> {
   data: T
   meta: M
 
@@ -12,7 +12,7 @@ export class SingleApiResult<T, M> {
   }
 }
 
-export class PaginatedApiResult<T, M> {
+export class ApiCollectionResult<T, M> {
   data: T[]
   meta: M
 

--- a/src/lib/Resource.ts
+++ b/src/lib/Resource.ts
@@ -1,8 +1,9 @@
 import { ValuesOf, ExtendsOrNever } from '../types/util'
 import { ResourceFields, ResourceField } from './ResourceField'
 import { ResourceIdentifier, ResourceIdentifierKey } from './ResourceIdentifier'
-import { RelationshipValue } from './ResourceRelationship'
+import { RelationshipValue, ToManyRelationship, ToOneRelationship } from './ResourceRelationship'
 import { AttributeValue } from './ResourceAttribute'
+import { BaseRelationshipResource } from './ApiQuery'
 
 export type ResourceType = string
 export type ResourceId = string
@@ -16,7 +17,19 @@ export type ResourceFieldNames<R extends AnyResource> = ExtendsOrNever<
 
 export type ResourceRelationshipNames<R extends AnyResource> = ValuesOf<
   {
-    [K in ResourceFieldNames<R>]: ResourceRelationship<R[K]> extends never ? never : K
+    [K in ResourceFieldNames<R>]: BaseRelationshipResource<R[K]> extends never ? never : K
+  }
+>
+
+export type ResourceToOneRelationshipNames<R extends AnyResource> = ValuesOf<
+  {
+    [K in ResourceFieldNames<R>]: R[K] extends ToOneRelationship<AnyResource> ? K : never
+  }
+>
+
+export type ResourceToManyRelationshipNames<R extends AnyResource> = ValuesOf<
+  {
+    [K in ResourceFieldNames<R>]: R[K] extends ToManyRelationship<AnyResource> ? K : never
   }
 >
 
@@ -39,13 +52,13 @@ type ResourceFieldsModel<F extends ResourceFields<any>> = {
     : never
 }
 
-export type ResourceRelationship<T> = null extends T
-  ? T extends AnyResource
-    ? Extract<T, AnyResource>
-    : never
-  : T extends Array<AnyResource>
-  ? T[number]
-  : never
+// export type BaseRelationshipResource<T> = null extends T
+//   ? T extends AnyResource
+//     ? Extract<T, AnyResource>
+//     : never
+//   : T extends Array<AnyResource>
+//   ? T[number]
+//   : never
 
 export const resource = <T extends ResourceType>(type: T) => {
   return class Resource<

--- a/src/lib/ResourceRelationship.ts
+++ b/src/lib/ResourceRelationship.ts
@@ -1,4 +1,4 @@
-import { or, isAny, isNull, array } from 'isntnt'
+import { or, isAny, isNull, array, Predicate } from 'isntnt'
 
 import { resourceFieldPropertyDescriptor } from '../constants/resourceFieldPropertyDescriptor'
 import { createIsResourceOfType } from '../utils/predicates'
@@ -14,12 +14,21 @@ export type RelationshipValue<R extends AnyResource> = ToOneRelationship<R> | To
 export class RelationshipField<T extends ResourceType> extends ResourceField<
   RelationshipValue<ResourceIdentifier<T>>
 > {
+  public type: T
+  constructor(
+    name: ResourceFieldName,
+    type: T,
+    predicate: Predicate<RelationshipValue<ResourceIdentifier<T>>>,
+  ) {
+    super(name, predicate)
+    this.type = type
+  }
   root: ResourceFieldRoot = 'relationships'
 }
 
 export class ToOneRelationshipField<T extends ResourceType> extends RelationshipField<T> {
   constructor(name: ResourceFieldName, type: T) {
-    super(name, or(isNull, createIsResourceOfType(type)))
+    super(name, type, or(isNull, createIsResourceOfType(type)))
   }
 
   isToOneRelationship: () => this is RelationshipField<T> & ToOneRelationshipField<T> = isAny as any
@@ -27,7 +36,7 @@ export class ToOneRelationshipField<T extends ResourceType> extends Relationship
 
 export class ToManyRelationshipField<T extends ResourceType> extends RelationshipField<T> {
   constructor(name: ResourceFieldName, type: T) {
-    super(name, array(createIsResourceOfType(type)))
+    super(name, type, array(createIsResourceOfType(type)))
   }
 
   isToManyRelationship: () => this is RelationshipField<T> &

--- a/src/test-utils/Entities.ts
+++ b/src/test-utils/Entities.ts
@@ -1,0 +1,25 @@
+import {requiredAttribute, resource, toManyRelationship, toOneRelationship} from "..";
+import {isString} from "isntnt";
+
+export class Post extends resource('Post')<Post> {
+  @requiredAttribute(isString) public title!: string
+  @requiredAttribute(isString) public content!: string
+
+  @toOneRelationship('Author') public author!: Author | null
+  @toManyRelationship('Comment') public comments!: Comment[]
+}
+
+export class Author extends resource('Author')<Author> {
+  @requiredAttribute(isString) public name!: string
+  @requiredAttribute(isString) public homepage!: string
+
+  @toManyRelationship('Comment') public comments!: Comment[]
+  @toManyRelationship('Post') public posts!: Post[]
+}
+
+export class Comment extends resource('Comment')<Comment> {
+  @requiredAttribute(isString) public title!: string
+
+  @toOneRelationship('Author') public author!: Author | null
+  @toManyRelationship('Post') public posts!: Post[]
+}

--- a/src/test-utils/mock-data.ts
+++ b/src/test-utils/mock-data.ts
@@ -1,0 +1,47 @@
+export const mockData = {
+  Post: {
+    p1: {
+      id: 'p1',
+      type: 'Post',
+      attributes: {
+        title: 'Post 1',
+        content: 'foo',
+      },
+      relationships: {
+        Author: {
+          data: {
+            type: 'Author',
+            id: 'a1',
+          },
+        },
+      },
+    },
+  },
+  Author: {
+    a1: {
+      id: 'a1',
+      type: 'Author',
+      attributes: {
+        name: 'Narie',
+      },
+    },
+  },
+  Comment: {
+    c1: {
+      id: 'c1',
+      type: 'Comment',
+      attributes: {
+        title: 'Comment 1',
+      },
+      relationships: {
+        Author: {
+          data: {
+            type: 'Author',
+            id: 'a1',
+          },
+        },
+      },
+
+    },
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,10 +3382,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.7.1-rc:
-  version "3.7.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.1-rc.tgz#2054b872d67f8dc732e36c1df397f9327f37ada0"
-  integrity sha512-2rMtWppLsaPvmpXsoIAXWDBQVnJMw1ITGGSnidMuayLj9iCmMRT69ncKZw/Mk5rXfJkilApKucWQZxproALoRw==
+typescript@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@^3.1.4:
   version "3.6.4"


### PR DESCRIPTION
* add two new methods on ApiEndpoint for fetching 'one' and 'many'
  relationship results
* add tests for those new methods (and update some older tests)
* restructure ApiEndpoint fetch methods to reduce duplication
* add types for 'one' and 'many' relationship names
* make entity type available on the RelationshipField object
* add some basic mock entities and data to run tests with