### PR TITLE
Add transformRelationshipForURL to ApiSetup

### DIFF
--- a/src/lib/ApiEndpoint.ts
+++ b/src/lib/ApiEndpoint.ts
@@ -138,7 +138,7 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
     return (this.fetchEntity(
       id,
       resourceFilter as any,
-      `/${relationshipFieldName}`,
+      `/${this.api.setup.transformRelationshipForURL!(relationshipFieldName)}`,
       relationshipField.type,
     ) as unknown) as Promise<ApiEntityResult<FilteredResource<RR, F>, any>>
   }
@@ -171,7 +171,7 @@ export class ApiEndpoint<R extends AnyResource, S extends Partial<ApiSetup>> {
       query as any,
       resourceFilter as any,
       id,
-      `${id}/${relationshipFieldName}`,
+      `${id}/${this.api.setup.transformRelationshipForURL!(relationshipFieldName)}`,
       relationshipField.type,
     ) as unknown) as Promise<ApiCollectionResult<FilteredResource<RR, F>, any>>
   }

--- a/src/lib/ApiSetup.ts
+++ b/src/lib/ApiSetup.ts
@@ -22,6 +22,7 @@ export type ApiSetup = {
   version: JsonApiVersion
   defaultIncludeFields: DefaultIncludeFieldsOption
   createPageQuery: ApiSetupCreatePageQuery
+  transformRelationshipForURL: Transform<string>
   parseRequestError: ApiSetupParseRequestError
   beforeRequest: Transform<SerializableObject>
   adapter: Window['fetch']
@@ -38,6 +39,7 @@ export type DefaultApiSetup = ApiSetupWithDefaults<{
   version: JsonApiVersions['1_0']
   defaultIncludeFields: DefaultIncludeFieldsOptions['NONE']
   createPageQuery: Transform<ApiQueryParameter, ApiQueryParameter>
+  transformRelationshipForURL: Transform<string>
   parseRequestError: Transform<ApiResponseError, any>
   beforeRequest: Transform<SerializableObject>
   adapter: Window['fetch']
@@ -57,6 +59,7 @@ export const mergeApiDefaultSetup = mergeApiSetup({
   version: jsonApiVersions['1_0'],
   defaultIncludeFields: defaultIncludeFieldOptions.NONE,
   createPageQuery: reflect,
+  transformRelationshipForURL: reflect,
   parseRequestError: reflect,
   beforeRequest: reflect,
   adapter: windowFetch,


### PR DESCRIPTION
This allows us to change the way a relationship field is put in the
URL when building up the request.

This can be useful if the relationship fieldnames are camelCase, but
in the URL they should be kebab-case.