### PR TITLE
Make sure that encodeResource always sets the type of the passed Resource

### DIFF
--- a/src/lib/ApiController.test.ts
+++ b/src/lib/ApiController.test.ts
@@ -1,0 +1,44 @@
+import { Client } from './Client'
+import { url } from '../../test/mocks'
+import { Post } from '../../test/resources'
+import { keys } from '../utils/data'
+
+describe('ApiController', () => {
+  describe('encodeResource', () => {
+    it('set the correct Resource type when type is passed', () => {
+      const client = new Client(url)
+      const result = client.controller.encodeResource(
+        Post,
+        { title: 'foo', type: Post.type } as any,
+        keys(Post.fields),
+        [],
+      )
+
+      expect(result.value.data).toEqual({ type: Post.type, attributes: { title: 'foo' } })
+    })
+
+    it('set the correct Resource type when type is omitted from the data', () => {
+      const client = new Client(url)
+      const result = client.controller.encodeResource(
+        Post,
+        { title: 'foo' } as any,
+        keys(Post.fields),
+        [],
+      )
+
+      expect(result.value.data).toEqual({ type: Post.type, attributes: { title: 'foo' } })
+    })
+
+    it('fail when the wrong Resource type is passed', () => {
+      const client = new Client(url)
+      const result = client.controller.encodeResource(
+        Post,
+        { title: 'foo', type: 'bar' } as any,
+        keys(Post.fields),
+        [],
+      )
+
+      expect(result.value[0].message).toEqual(`Invalid type for Resource of type ${Post.type}`)
+    })
+  })
+})

--- a/src/lib/ApiController.ts
+++ b/src/lib/ApiController.ts
@@ -303,9 +303,9 @@ export class ApiController<S extends Partial<ClientSetup>> {
           pointer.concat(ResourceDocumentKey.TYPE),
         ),
       )
-    } else {
-      data[ResourceDocumentKey.TYPE] = values[ResourceDocumentKey.TYPE]
     }
+
+    data[ResourceDocumentKey.TYPE] = Resource[ResourceDocumentKey.TYPE]
 
     if (ResourceDocumentKey.ID in values) {
       if (isString(values[ResourceDocumentKey.ID])) {


### PR DESCRIPTION
Previously, it was required to always pass the type in the values, which
is not how patch is usually used.

This will now set the type of the Resource instead of from the values.

It still keeps the validation in place to check that IF you pass a type
in the values, it errors if it doesn't match with the Resource type.

Also added unit tests for the 3 relevant cases