### PR TITLE
Allow using alternative paths for Resource Endpoints

### DIFF
--- a/src/lib/Client.test.ts
+++ b/src/lib/Client.test.ts
@@ -94,5 +94,13 @@ describe('Client', () => {
 
       expect(endpoint.client).toEqual(client)
     })
+
+    it('should be used with an alternate path', () => {
+      const client = new Client(url)
+
+      const endpoint = client.endpoint(Post, 'foo')
+
+      expect(endpoint.Resource.path).toEqual('foo')
+    })
   })
 })

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -1,6 +1,6 @@
 import { ApiController } from './ApiController'
 import { Endpoint } from './Endpoint'
-import { AnyResource, ResourceConstructor } from './Resource'
+import { AnyResource, cloneResourceWithPath, ResourceConstructor } from './Resource'
 import { JSONAPISearchParameters, JSONAPIParameterValue } from '../utils/url'
 import { Transform } from '../types/util'
 import { JSONAPIErrorObject } from '../types/data'
@@ -26,8 +26,20 @@ export class Client<S extends Partial<ClientSetup>> {
     this.controller = new ApiController(this)
   }
 
-  endpoint<R extends AnyResource>(Resource: ResourceConstructor<R>): Endpoint<R, S> {
-    return new Endpoint(this, Resource)
+  /**
+   * Creates an endpoint tied to the passed Resource.
+   * By default, the endpoint will use the path defined in the Resource.
+   * Alternatively, it's possible to provide an alternative path if the Resource is used for
+   * different endpoints.
+   */
+  endpoint<R extends AnyResource>(
+    Resource: ResourceConstructor<R>,
+    alternativePath?: string,
+  ): Endpoint<R, S> {
+    return new Endpoint(
+      this,
+      alternativePath ? cloneResourceWithPath(Resource, alternativePath) : Resource,
+    )
   }
 
   register(...resources: Array<ResourceConstructor<any>>): void {

--- a/src/lib/Resource.test.ts
+++ b/src/lib/Resource.test.ts
@@ -1,0 +1,11 @@
+import {Post} from "../../test/resources";
+import {cloneResourceWithPath} from "./Resource";
+
+describe('Resource', () => {
+  describe('cloneResourceWithPath', () => {
+    it('should return a cloned resource with updated path', () => {
+      expect(Post.path).toEqual('posts')
+      expect(cloneResourceWithPath(Post, 'foo').path).toEqual('foo')
+    })
+  })
+})

--- a/src/lib/Resource.ts
+++ b/src/lib/Resource.ts
@@ -6,6 +6,16 @@ import { ResourceFields, ResourceField } from './ResourceField'
 import { ResourceIdentifier, ResourceIdentifierKey } from './ResourceIdentifier'
 import { RelationshipValue, AttributeValue } from './ResourceField'
 
+// Updates the resource path in a cloned Resource to be used in a different endpoint
+export const cloneResourceWithPath = <T extends ResourceConstructor<any>>(
+  Resource: T,
+  alternativePath: string,
+): T => {
+  return Object.assign(Object.create(Object.getPrototypeOf(Resource)), Resource, {
+    path: alternativePath,
+  })
+}
+
 export type ResourceType = string
 export type ResourceId = string
 


### PR DESCRIPTION
By adding an optional 2nd path parameter, and cloning the passed
Resource with that alternative path, the created endpoint will receive
the new path.

And added relevant unit tests