### PR TITLE
Make beforeRequest in ClientSetup optionally async

### DIFF
--- a/src/lib/ApiController.ts
+++ b/src/lib/ApiController.ts
@@ -65,7 +65,7 @@ export class ApiController<S extends Partial<ClientSetup>> {
       }
     }
 
-    const request = this.client.setup.beforeRequest!(new Request(url.href, options) as any)
+    const request = await this.client.setup.beforeRequest!(new Request(url.href, options) as any)
     const response = await this.client.setup.fetchAdapter!(request as any)
     if (!response.ok) {
       const errorMessage = response.statusText || `Request Error ${response.status}`

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -2,7 +2,7 @@ import { ApiController } from './ApiController'
 import { Endpoint } from './Endpoint'
 import { AnyResource, cloneResourceWithPath, ResourceConstructor } from './Resource'
 import { JSONAPISearchParameters, JSONAPIParameterValue } from '../utils/url'
-import { Transform } from '../types/util'
+import { AsyncTransform, Transform } from '../types/util'
 import { JSONAPIErrorObject } from '../types/data'
 import { __DEV__ } from '../constants/data'
 
@@ -61,7 +61,7 @@ export type ClientSetup = {
   createPageQuery: CreatePageQuery
   transformRelationshipForURL: Transform<string>
   parseErrorObject: ParseJSONAPIErrorObject
-  beforeRequest: Transform<Request>
+  beforeRequest: Transform<Request> | AsyncTransform<Request>
   fetchAdapter: Window['fetch']
 }
 

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,4 +1,5 @@
 export type Transform<I, O = I> = (value: I, ...rest: Array<unknown>) => O
+export type AsyncTransform<I, O = I> = (value: I, ...rest: Array<unknown>) => Promise<O>
 export type Effect = Transform<void>
 export type Affect<T> = Transform<T, void>
 export type Fabricate<T> = Transform<void, T>

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -3,7 +3,9 @@ Object.assign(global, {
   Headers: class MockHeaders {
     append() {}
   },
-  Request: class MockRequest {},
+  Request: class MockRequest {
+    constructor(public url: string, public options: any) {}
+  },
 })
 
 export const url = new URL('https://www.example.com/api')


### PR DESCRIPTION
This allows the beforeRequest hook to execute some async logic before
continuing with the request itself.

Includes unit tests.